### PR TITLE
simplify the GuiceModule and make it pass Plays the config to Kamon, fixes #1

### DIFF
--- a/kamon-play-2.4.x/src/main/resources/reference.conf
+++ b/kamon-play-2.4.x/src/main/resources/reference.conf
@@ -31,4 +31,4 @@ kamon {
 }
 
 #register the module with Play
-play.modules.enabled += "kamon.play.di.KamonModule"
+play.modules.enabled += "kamon.play.di.GuiceModule"

--- a/kamon-play-2.5.x/src/main/resources/reference.conf
+++ b/kamon-play-2.5.x/src/main/resources/reference.conf
@@ -31,4 +31,4 @@ kamon {
 }
 
 #register the module with Play
-play.modules.enabled += "kamon.play.di.KamonModule"
+play.modules.enabled += "kamon.play.di.GuiceModule"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     "Kamon Repository Snapshots" at "http://snapshots.kamon.io"
   )
 
-  val kamonVersion      = "0.6.3"
+  val kamonVersion      = "0.6.5"
   val aspectjVersion    = "1.8.9"
   val play23Version     = "2.3.10"
   val play24Version     = "2.4.8"


### PR DESCRIPTION
This cannot be merged until we release the very latest version of core with kamon-io/kamon#421 merged in, but so far this seems to work nicely. We still need to fix a small issue with the location of the `application.conf` file, but that will be managed with the playrunner project.