### PR TITLE
Insert the KamonFilter at the beginning on the chain...

### DIFF
--- a/kamon-play-2.4.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
+++ b/kamon-play-2.4.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
@@ -42,7 +42,7 @@ class RequestInstrumentation {
   }
 
   @Around("call(* play.api.http.HttpFilters.filters(..))")
-  def filters(pjp: ProceedingJoinPoint): Any = pjp.proceed().asInstanceOf[Seq[EssentialFilter]] :+ filter
+  def filters(pjp: ProceedingJoinPoint): Any = filter +: pjp.proceed().asInstanceOf[Seq[EssentialFilter]]
 
   @Before("call(* play.api.http.HttpErrorHandler.onClientServerError(..)) && args(requestContextAware, statusCode, *)")
   def onClientError(requestContextAware: TraceContextAware, statusCode: Int): Unit = {

--- a/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
+++ b/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
@@ -45,7 +45,7 @@ class RequestInstrumentation {
 
   @Around("call(* play.api.http.HttpFilters.filters(..))")
   def filters(pjp: ProceedingJoinPoint): Any = {
-    pjp.proceed().asInstanceOf[Seq[EssentialFilter]] :+ filter
+    filter +: pjp.proceed().asInstanceOf[Seq[EssentialFilter]]
   }
 
   @Before("call(* play.api.http.HttpErrorHandler.onClientServerError(..)) && args(requestContextAware, statusCode, *)")


### PR DESCRIPTION
rather than the end.

The filters actions chained to the result accumulator run in the
opposite order as the filters themselves.

This should keep the TraceContext open longer which will allow other filters which chain off the Accumulator to interact with the TraceContext (see added test case) as well as give more accurate timing. 