### PR TITLE
Preserve any additional context received over HTTP other than the remote Span

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val play24Version     = "2.4.11"
 val play25Version     = "2.5.18"
 val play26Version     = "2.6.10"
 
-val kamonCore         = "io.kamon"                  %%  "kamon-core"            % "1.0.0"
+val kamonCore         = "io.kamon"                  %%  "kamon-core"            % "1.1.0"
 val kamonScala        = "io.kamon"                  %%  "kamon-scala-future"    % "1.0.0"
 val kamonTestkit      = "io.kamon"                  %%  "kamon-testkit"         % "1.0.0"
 

--- a/kamon-play-2.4.x/src/test/resources/conf/application.conf
+++ b/kamon-play-2.4.x/src/test/resources/conf/application.conf
@@ -6,6 +6,11 @@ kamon {
   trace {
     sampler = always
   }
+
+  context.codecs.string-keys {
+    request-id = "X-Request-ID"
+  }
+
   play {
     name-generator = kamon.play.TestNameGenerator
   }

--- a/kamon-play-2.4.x/src/test/scala/kamon/play/RequestHandlerInstrumentationSpec.scala
+++ b/kamon-play-2.4.x/src/test/scala/kamon/play/RequestHandlerInstrumentationSpec.scala
@@ -19,6 +19,7 @@ import javax.inject.Inject
 
 import kamon.Kamon
 import kamon.context.Context.create
+import kamon.context.Key
 import kamon.play.action.OperationName
 import kamon.trace.Span
 import kamon.trace.Span.TagValue
@@ -47,8 +48,10 @@ class RequestHandlerInstrumentationSpec extends PlaySpec with OneServerPerSuite
 
   implicit val executor: ExecutionContextExecutor = scala.concurrent.ExecutionContext.Implicits.global
 
+  val requestID = Key.broadcastString("request-id")
   val routes: PartialFunction[(String, String), Handler] = {
     case ("GET", "/ok") ⇒ Action { Ok }
+    case ("GET", "/request-id") ⇒ Action { Ok(Kamon.currentContext().get(requestID).getOrElse("undefined")) }
     case ("GET", "/async") ⇒ Action.async { Future { Ok } }
     case ("GET", "/not-found") ⇒ Action { NotFound }
     case ("GET", "/renamed") ⇒
@@ -93,6 +96,18 @@ class RequestHandlerInstrumentationSpec extends PlaySpec with OneServerPerSuite
         span.tags("span.kind") mustBe TagValue.String("server")
         span.tags("http.method") mustBe TagValue.String("GET")
         span.tags("http.status_code") mustBe TagValue.Number(200)
+      }
+    }
+
+    "propagate automatic broadcast string keys" in {
+      val wsClient = app.injector.instanceOf[WSClient]
+      val okSpan = Kamon.buildSpan("ok-operation-span").start()
+      val endpoint = s"http://localhost:$port/request-id"
+
+      Kamon.withContext(create(Span.ContextKey, okSpan).withKey(requestID, Some("123456"))) {
+        val response = await(wsClient.url(endpoint).get())
+        response.status mustBe 200
+        response.body mustBe "123456"
       }
     }
 

--- a/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestHandlerInstrumentation.scala
+++ b/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/RequestHandlerInstrumentation.scala
@@ -43,7 +43,7 @@ class RequestHandlerInstrumentation {
       .withTag("http.url", request.getUri)
       .start()
 
-    val responseFuture = Kamon.withContext(Context.create(Span.ContextKey, serverSpan)) {
+    val responseFuture = Kamon.withContext(incomingContext.withKey(Span.ContextKey, serverSpan)) {
       pjp.proceed().asInstanceOf[Future[HttpResponse]]
     }
 

--- a/kamon-play-2.5.x/src/test/resources/conf/application.conf
+++ b/kamon-play-2.5.x/src/test/resources/conf/application.conf
@@ -6,6 +6,11 @@ kamon {
   trace {
     sampler = always
   }
+
+  context.codecs.string-keys {
+    request-id = "X-Request-ID"
+  }
+
   play {
     name-generator = kamon.play.TestNameGenerator
   }

--- a/kamon-play-2.6.x/src/main/scala/kamon/play/instrumentation/RequestHandlerInstrumentation.scala
+++ b/kamon-play-2.6.x/src/main/scala/kamon/play/instrumentation/RequestHandlerInstrumentation.scala
@@ -43,7 +43,7 @@ class RequestHandlerInstrumentation {
       .withTag("http.url", request.getUri.toString)
       .start()
 
-    val responseFuture = Kamon.withContext(Context.create(Span.ContextKey, serverSpan)) {
+    val responseFuture = Kamon.withContext(incomingContext.withKey(Span.ContextKey, serverSpan)) {
       pjp.proceed().asInstanceOf[Future[HttpResponse]]
     }
 

--- a/kamon-play-2.6.x/src/test/resources/conf/application.conf
+++ b/kamon-play-2.6.x/src/test/resources/conf/application.conf
@@ -6,6 +6,11 @@ kamon {
   trace {
     sampler = always
   }
+
+  context.codecs.string-keys {
+    request-id = "X-Request-ID"
+  }
+
   play {
     name-generator = kamon.play.TestNameGenerator
   }

--- a/kamon-play-2.6.x/src/test/scala/kamon/play/RequestInstrumentationSpec.scala
+++ b/kamon-play-2.6.x/src/test/scala/kamon/play/RequestInstrumentationSpec.scala
@@ -19,6 +19,7 @@ import javax.inject.Inject
 
 import kamon.Kamon
 import kamon.context.Context.create
+import kamon.context.Key
 import kamon.play.action.OperationName
 import kamon.testkit.MetricInspection
 import kamon.trace.Span
@@ -54,9 +55,10 @@ class RequestHandlerInstrumentationSpec extends PlaySpec with GuiceOneServerPerS
 
   implicit val executor: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-
+  val requestID = Key.broadcastString("request-id")
   val withRoutes: PartialFunction[(String, String), Handler] = {
     case ("GET", "/ok") ⇒ Action { Ok }
+    case ("GET", "/request-id") ⇒ Action { Ok(Kamon.currentContext().get(requestID).getOrElse("undefined")) }
     case ("GET", "/async") ⇒ Action.async { Future { Ok } }
     case ("GET", "/not-found") ⇒ Action { NotFound }
     case ("GET", "/renamed") ⇒
@@ -102,6 +104,18 @@ class RequestHandlerInstrumentationSpec extends PlaySpec with GuiceOneServerPerS
         span.tags("span.kind") mustBe TagValue.String("server")
         span.tags("http.method") mustBe TagValue.String("GET")
         span.tags("http.status_code") mustBe TagValue.Number(200)
+      }
+    }
+
+    "propagate automatic broadcast string keys" in {
+      val wsClient = app.injector.instanceOf[WSClient]
+      val okSpan = Kamon.buildSpan("ok-operation-span").start()
+      val endpoint = s"http://localhost:$port/request-id"
+
+      Kamon.withContext(create(Span.ContextKey, okSpan).withKey(requestID, Some("123456"))) {
+        val response = await(wsClient.url(endpoint).get())
+        response.status mustBe 200
+        response.body mustBe "123456"
       }
     }
 


### PR DESCRIPTION
For Play 2.5 and 2.6 parts of the incoming context would be lost because the instrumentation was always creating a new `Context` instance that would only have the newly created Span inside. This PR fixed that bug.